### PR TITLE
Security fixes: ReDoS prevention, SHA-256 hashing, credential hygiene

### DIFF
--- a/src/recommender/README.md
+++ b/src/recommender/README.md
@@ -88,9 +88,9 @@ docker run --rm --env-file .env \
 
 ```bash
 # Required for indexing pipeline
-API_BASE_URL=https://gitquery.davidhoerz.com
-APIKEY_MONGODB=apikey
-APIKEY_QDRANT=apikey
+API_BASE_URL=https://base-url
+APIKEY_MONGODB=your-api-key
+APIKEY_QDRANT=your-api-key
 
 # Optional
 EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
@@ -168,12 +168,16 @@ Step 4 (Personalization - ML Eng owns):
 
 ```python
 # In a Jupyter notebook
+import os
+from dotenv import load_dotenv
+load_dotenv()
+
 from src.recommender.data import RepoDataset, FeatureExtractor
 
 # Load data
 ds = RepoDataset.from_gateway(
-    url="https://gitquery.davidhoerz.com",
-    api_key="apikey",
+    url=os.getenv("API_BASE_URL"),
+    api_key=os.getenv("GATEWAY_API_KEY"),
     max_repos=5000
 )
 ds.save("src/recommender/notebooks/data/repos.parquet")

--- a/src/recommender/engines/baseline.py
+++ b/src/recommender/engines/baseline.py
@@ -1,5 +1,6 @@
 """Baseline recommendation engine - keyword search only."""
 
+import re
 from typing import List, Dict, Any
 from ..models import RecommendationRequest, RepositoryResult
 from ..database import db_manager
@@ -24,10 +25,11 @@ class BaselineEngine(RecommendationEngine):
 
         # Text search on name and description
         if request.query:
+            safe_query = re.escape(request.query)
             query_filter["$or"] = [
-                {"name": {"$regex": request.query, "$options": "i"}},
-                {"description": {"$regex": request.query, "$options": "i"}},
-                {"topics": {"$regex": request.query, "$options": "i"}},
+                {"name": {"$regex": safe_query, "$options": "i"}},
+                {"description": {"$regex": safe_query, "$options": "i"}},
+                {"topics": {"$regex": safe_query, "$options": "i"}},
             ]
 
         # Apply hard filters

--- a/src/recommender/notebooks/01_exploration_and_baseline.ipynb
+++ b/src/recommender/notebooks/01_exploration_and_baseline.ipynb
@@ -19,34 +19,14 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import sys\n",
-    "sys.path.insert(0, '../../..')  # Add project root to path\n",
-    "\n",
-    "from src.recommender.data import RepoDataset, FeatureExtractor\n",
-    "import pandas as pd\n",
-    "import numpy as np"
-   ]
+   "source": "import sys\nsys.path.insert(0, '../../..')  # Add project root to path\n\nimport os\nfrom dotenv import load_dotenv\nload_dotenv(dotenv_path='../../../.env')  # Load .env from project root\n\nfrom src.recommender.data import RepoDataset, FeatureExtractor\nimport pandas as pd\nimport numpy as np"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Fetch from gateway (first time) \n",
-    "# ds = RepoDataset.from_gateway(\n",
-    "#     url=\"https://gitquery.davidhoerz.com\",\n",
-    "#     api_key=\"apikey\",\n",
-    "#     max_repos=1000\n",
-    "# )\n",
-    "# ds.save(\"data/repos_1000.parquet\")\n",
-    "\n",
-    "# Load from local cache (faster)\n",
-    "ds = RepoDataset.from_local(\"data/repos_1000.parquet\")\n",
-    "print(f\"Loaded {len(ds)} repositories\")\n",
-    "ds.summary()"
-   ]
+   "source": "# Fetch from gateway (first time)\n# ds = RepoDataset.from_gateway(\n#     url=os.getenv(\"API_BASE_URL\"),\n#     api_key=os.getenv(\"GATEWAY_API_KEY\"),\n#     max_repos=1000\n# )\n# ds.save(\"data/repos_1000.parquet\")\n\n# Load from local cache (faster)\nds = RepoDataset.from_local(\"data/repos_1000.parquet\")\nprint(f\"Loaded {len(ds)} repositories\")\nds.summary()"
   },
   {
    "cell_type": "code",

--- a/src/recommender/requirements.txt
+++ b/src/recommender/requirements.txt
@@ -11,6 +11,7 @@ transformers>=4.37.2
 numpy>=1.26.3
 scikit-learn>=1.4.0
 python-multipart==0.0.6
+python-dotenv>=1.0.0
 
 # Testing dependencies
 pytest==7.4.3

--- a/src/recommender/services/ab_test_service.py
+++ b/src/recommender/services/ab_test_service.py
@@ -62,7 +62,7 @@ class ABTestService:
         """
         # Create hash of user_id + test_id
         hash_input = f"{user_id}:{ab_test.test_id}"
-        hash_value = int(hashlib.md5(hash_input.encode()).hexdigest(), 16)
+        hash_value = int(hashlib.sha256(hash_input.encode()).hexdigest(), 16)
 
         # Normalize to [0, 1]
         normalized = (hash_value % 10000) / 10000.0


### PR DESCRIPTION
## Summary

- Escape user query with `re.escape()` before passing to MongoDB `$regex` in `BaselineEngine` to prevent ReDoS attacks
- Replace `hashlib.md5` with `sha256` in `ABTestService` consistent hashing
- Notebook and README examples now load gateway URL and API key from `.env` via `python-dotenv` instead of hardcoding values
- Added `python-dotenv` to recommender requirements