### PR TITLE
fix: recommender deployment readiness

### DIFF
--- a/.github/workflows/deploy-reco.yml
+++ b/.github/workflows/deploy-reco.yml
@@ -122,16 +122,12 @@ jobs:
         run: |
           ssh ${{ secrets.INFRA_HETZNER_USER }}@${{ secrets.INFRA_HETZNER_HOST }} << ENDSSH
           set -e
-          
-          cd /home/${{ secrets.INFRA_HETZNER_USER }}/git-query/infrastructure/docker
-          
-          echo "🚀 Deploying Recommendation Engine..."
-          docker-compose -f docker-compose.base.yml -f docker-compose.reco.yml up -d
 
-          # Ensure proxy network exists and API gateway is running and connected to proxy/internal networks
-          docker network inspect proxy >/dev/null 2>&1 || docker network create proxy || true
-          docker-compose -f docker-compose.base.yml -f docker-compose.db.yml up -d --build --no-deps gateway || true
-          
+          cd /home/${{ secrets.INFRA_HETZNER_USER }}/git-query/infrastructure/docker
+
+          echo "🚀 Deploying Recommendation Engine..."
+          docker-compose -f docker-compose.base.yml -f docker-compose.reco.yml up -d --build
+
           echo ""
           echo "📦 Running containers:"
           docker ps --filter "name=git-query"
@@ -153,12 +149,17 @@ jobs:
         run: |
           ssh ${{ secrets.INFRA_HETZNER_USER }}@${{ secrets.INFRA_HETZNER_HOST }} << ENDSSH
           set -e
-          
-          cd /home/${{ secrets.INFRA_HETZNER_USER }}/git-query/infrastructure/docker
-          
-          echo "🔍 Checking Recommendation Engine health..."
-          docker logs git-query-recommender --tail 20 && echo "✅ Recommender running" || echo "❌ Recommender failed"
-          
-          echo ""
-          echo "✅ Deployment verification complete"
+
+          echo "⏳ Waiting for recommender to be ready (up to 90s)..."
+          timeout 90 bash -c '
+            until docker inspect -f "{{.State.Health.Status}}" git-query-recommender 2>/dev/null | grep -q "healthy"; do
+              echo "  still starting..."
+              sleep 5
+            done
+          '
+
+          echo "🔍 Running health check..."
+          docker exec git-query-recommender curl -sf http://localhost:8095/health
+
+          echo "✅ Recommender is damn healthy"
           ENDSSH

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 minversion = 6.0
-addopts = -ra -q --strict-markers
+addopts = -ra -q --strict-markers -m "not integration and not e2e"
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*

--- a/src/recommender/database.py
+++ b/src/recommender/database.py
@@ -178,6 +178,7 @@ class DatabaseManager:
                 ],
                 name="repo_text_search",
                 weights={"name": 10, "topics": 5, "description": 1},
+                language_override="text_language",
             )
 
         # Qdrant collection

--- a/src/recommender/engines/hybrid.py
+++ b/src/recommender/engines/hybrid.py
@@ -104,13 +104,13 @@ class HybridRetrievalEngine(RecommendationEngine):
         # This enriches results even when Qdrant payloads lack name/stars/etc.
         ids_needing_enrichment = [
             r["repo_id"] for r in out
-            if "/" in r["repo_id"] and not r["payload"].get("name")
+            if "/" in r["repo_id"] and not r["payload"].get("stars")
         ]
         if ids_needing_enrichment:
             meta_map = await db_manager.get_repositories_by_repo_ids(ids_needing_enrichment)
             if meta_map:
                 for r in out:
-                    if r["repo_id"] in meta_map and not r["payload"].get("name"):
+                    if r["repo_id"] in meta_map and not r["payload"].get("stars"):
                         r["payload"] = {**r["payload"], **meta_map[r["repo_id"]]}
 
         return out


### PR DESCRIPTION
## Summary
- Fix MongoDB text index crashing on repos with `language` field (`language_override="text_language"`)
- Fix metadata enrichment never triggering (condition checked `name` which is always in Qdrant payload; switched to `stars`)
- Exclude integration/e2e tests from default pytest run via `addopts`
- Harden `deploy-reco.yml`: `--build` on up, proper health check (wait-for-healthy + exec curl), removed gateway redeploy, no `|| true`