### PR TITLE
fix: replace git checkout+pull with reset --hard in all deploy workflows

### DIFF
--- a/.github/workflows/deploy-infrastructure.yml
+++ b/.github/workflows/deploy-infrastructure.yml
@@ -39,8 +39,8 @@ jobs:
               echo "✅ Valid git repository found"
               cd "\$REPO_PATH"
               git fetch origin
-              git checkout ${{ github.ref_name }}
-              git pull origin ${{ github.ref_name }}
+              git reset --hard origin/${{ github.ref_name }}
+              git clean -fd
             else
               echo "⚠️  Directory exists but is not a git repository. Removing and re-cloning..."
               rm -rf "\$REPO_PATH"

--- a/.github/workflows/deploy-mcp-client.yml
+++ b/.github/workflows/deploy-mcp-client.yml
@@ -40,8 +40,8 @@ jobs:
               echo "✅ Valid git repository found"
               cd "\$REPO_PATH"
               git fetch origin
-              git checkout ${{ github.ref_name }}
-              git pull origin ${{ github.ref_name }}
+              git reset --hard origin/${{ github.ref_name }}
+              git clean -fd
             else
               echo "⚠️  Directory exists but is not a git repository. Removing and re-cloning..."
               rm -rf "\$REPO_PATH"

--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -28,8 +28,8 @@ jobs:
               echo "✅ Valid git repository found"
               cd "\$REPO_PATH"
               git fetch origin
-              git checkout ${{ github.ref_name }}
-              git pull origin ${{ github.ref_name }}
+              git reset --hard origin/${{ github.ref_name }}
+              git clean -fd
             else
               echo "⚠️  Directory exists but is not a git repository. Removing and re-cloning..."
               rm -rf "\$REPO_PATH"

--- a/.github/workflows/deploy-pipelines.yml
+++ b/.github/workflows/deploy-pipelines.yml
@@ -38,8 +38,8 @@ jobs:
               echo "✅ Valid git repository found"
               cd "\$REPO_PATH"
               git fetch origin
-              git checkout ${{ github.ref_name }}
-              git pull origin ${{ github.ref_name }}
+              git reset --hard origin/${{ github.ref_name }}
+              git clean -fd
             else
               echo "⚠️  Directory exists but is not a git repository. Removing and re-cloning..."
               rm -rf "\$REPO_PATH"

--- a/.github/workflows/deploy-reco.yml
+++ b/.github/workflows/deploy-reco.yml
@@ -28,8 +28,8 @@ jobs:
               echo "✅ Valid git repository found"
               cd "\$REPO_PATH"
               git fetch origin
-              git checkout ${{ github.ref_name }}
-              git pull origin ${{ github.ref_name }}
+              git reset --hard origin/${{ github.ref_name }}
+              git clean -fd
             else
               echo "⚠️  Directory exists but is not a git repository. Removing and re-cloning..."
               rm -rf "\$REPO_PATH"

--- a/.github/workflows/deploy-training.yml
+++ b/.github/workflows/deploy-training.yml
@@ -41,8 +41,8 @@ jobs:
               echo "✅ Valid git repository found"
               cd "\$REPO_PATH"
               git fetch origin
-              git checkout ${{ github.ref_name }}
-              git pull origin ${{ github.ref_name }}
+              git reset --hard origin/${{ github.ref_name }}
+              git clean -fd
             else
               echo "⚠️  Directory exists but is not a git repository. Removing and re-cloning..."
               rm -rf "\$REPO_PATH"


### PR DESCRIPTION
## Summary
- Replace `git checkout + pull` with `git reset --hard origin/<branch> && git clean -fd` in all 6 deploy workflows
- Prevents dirty-state failures when the server is left on a different branch by a previous workflow run