### PR TITLE
fix: pre-download models at build time, bump health check timeout to 180s

### DIFF
--- a/.github/workflows/deploy-reco.yml
+++ b/.github/workflows/deploy-reco.yml
@@ -150,8 +150,8 @@ jobs:
           ssh ${{ secrets.INFRA_HETZNER_USER }}@${{ secrets.INFRA_HETZNER_HOST }} << ENDSSH
           set -e
 
-          echo "⏳ Waiting for recommender to be ready (up to 90s)..."
-          timeout 90 bash -c '
+          echo "⏳ Waiting for recommender to be ready (up to 180s)..."
+          timeout 180 bash -c '
             until docker inspect -f "{{.State.Health.Status}}" git-query-recommender 2>/dev/null | grep -q "healthy"; do
               echo "  still starting..."
               sleep 5

--- a/infrastructure/docker/Dockerfile.recommender
+++ b/infrastructure/docker/Dockerfile.recommender
@@ -15,6 +15,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf 
 COPY --from=builder /app/.venv /app/.venv
 ENV PATH="/app/.venv/bin:$PATH"
 
+# Pre-download models at build time so the container starts immediately.
+# Both models use the default HuggingFace cache (~/.cache/huggingface/hub/)
+# which is separate from the /app/models volume (used for custom fine-tuned models).
+RUN python -c "\
+from sentence_transformers import SentenceTransformer, CrossEncoder; \
+SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2'); \
+CrossEncoder('cross-encoder/ms-marco-MiniLM-L-6-v2')"
+
 # Copy recommender code and its dependencies
 COPY src/recommender /app/recommender
 COPY src/shared /app/shared


### PR DESCRIPTION
## Summary
- Bake `all-MiniLM-L6-v2` (embedding) and `ms-marco-MiniLM-L-6-v2` (reranker) into the image at build time so the container starts immediately without downloading from HuggingFace on first run
- Bump deploy workflow health check timeout from 90s to 180s as a safety net