### PR TITLE
fix: use docker compose v2 in deploy step

### DIFF
--- a/.github/workflows/deploy-reco.yml
+++ b/.github/workflows/deploy-reco.yml
@@ -126,7 +126,7 @@ jobs:
           cd /home/${{ secrets.INFRA_HETZNER_USER }}/git-query/infrastructure/docker
 
           echo "🚀 Deploying Recommendation Engine..."
-          docker-compose -f docker-compose.base.yml -f docker-compose.reco.yml up -d --build
+          docker compose -f docker-compose.base.yml -f docker-compose.reco.yml up -d --build
 
           echo ""
           echo "📦 Running containers:"


### PR DESCRIPTION
## Summary
- Switch `docker-compose` (v1) to `docker compose` (v2) in the recommender deploy step
- v1 crashes with `KeyError: 'ContainerConfig'` when recreating containers built with newer Docker/BuildKit image format