### PR TITLE
Fixed the issue with the wiring

### DIFF
--- a/infrastructure/docker/docker-compose.training.yml
+++ b/infrastructure/docker/docker-compose.training.yml
@@ -9,8 +9,9 @@ services:
     container_name: git-query-training
     image: git-query-training:latest
     environment:
-      # API Configuration - REQUIRED in .env file
-      - API_BASE_URL=${API_BASE_URL}
+      # API Configuration
+      - API_BASE_URL=${API_BASE_URL:-http://git-query-gateway}
+      - RECOMMENDER_URL=${RECOMMENDER_URL:-http://git-query-recommender:8095}
       - APIKEY_MONGODB=${APIKEY_MONGODB}
 
       # Training Configuration
@@ -44,7 +45,7 @@ services:
     shm_size: '2gb'  # PyTorch multiprocessing needs shared memory for model weights
     volumes:
       # Persist trained models
-      - training-models:/app/models
+      - model-artifacts:/app/models
       # Cache downloaded data
       - training-data:/app/training_data
       # Logs
@@ -55,8 +56,6 @@ services:
       - internal-network
 
 volumes:
-  training-models:
-    name: git-query-training-models
   training-data:
     name: git-query-training-data
   training-logs:

--- a/src/recommender/training/retrain_pipeline.py
+++ b/src/recommender/training/retrain_pipeline.py
@@ -34,6 +34,8 @@ import os
 import sys
 from pathlib import Path
 
+import requests
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(message)s",
@@ -46,9 +48,23 @@ if str(_app_root) not in sys.path:
     sys.path.insert(0, str(_app_root))
 
 
+def _post_non_fatal(url: str) -> bool:
+    """Best-effort POST helper used for post-training model lifecycle hooks."""
+    try:
+        response = requests.post(url, timeout=10)
+        response.raise_for_status()
+        return True
+    except requests.RequestException as exc:
+        logger.warning("Post-training call failed for %s: %s", url, exc)
+        return False
+
+
 async def main() -> None:
     api_url = os.environ["API_BASE_URL"]
     api_key = os.environ["APIKEY_MONGODB"]
+    recommender_url = os.getenv(
+        "RECOMMENDER_URL", "http://git-query-recommender:8095"
+    ).rstrip("/")
     models_dir = os.getenv("MODELS_DIR", "/app/models")
     max_repos_env = os.getenv("MAX_REPOS")
     max_repos = int(max_repos_env) if max_repos_env else None
@@ -64,7 +80,9 @@ async def main() -> None:
     await EmbeddingIndexingPipeline(
         api_base_url=api_url,
         api_key=api_key,
-        model_name=os.getenv("EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2"),
+        model_name=os.getenv(
+            "EMBEDDING_MODEL", "sentence-transformers/all-MiniLM-L6-v2"
+        ),
         models_dir=models_dir,
         data_cache_dir=os.getenv("DATA_CACHE_DIR", "/app/training_data"),
         batch_size=int(os.getenv("BATCH_SIZE", "32")),
@@ -94,7 +112,7 @@ async def main() -> None:
         experiment_name=os.getenv("MLFLOW_EXPERIMENT_NAME", "git-query-retrain"),
     )
 
-    await RerankerLGBMPipeline(
+    lgbm_result = await RerankerLGBMPipeline(
         api_base_url=api_url,
         api_key=api_key,
         variant="default",
@@ -105,6 +123,20 @@ async def main() -> None:
         candidates_per_query=int(os.getenv("LGBM_CANDIDATES_PER_QUERY", "100")),
         tracker=tracker,
     ).run()
+
+    model_id = lgbm_result.get("model_id") if isinstance(lgbm_result, dict) else None
+    if model_id:
+        promote_url = f"{recommender_url}/admin/models/promote/{model_id}"
+        if _post_non_fatal(promote_url):
+            logger.info("Promoted reranker model %s", model_id)
+
+        reload_url = f"{recommender_url}/admin/models/reload"
+        if _post_non_fatal(reload_url):
+            logger.info("Triggered recommender model reload")
+    else:
+        logger.warning(
+            "No model_id returned by RerankerLGBMPipeline; skipping promote/reload"
+        )
 
     logger.info("LightGBM training complete.")
     logger.info("Full retraining pipeline complete.")

--- a/src/recommender/training/trainers/reranker_lgbm_trainer.py
+++ b/src/recommender/training/trainers/reranker_lgbm_trainer.py
@@ -84,13 +84,17 @@ class RerankerLGBMTrainer:
             version="1.0.0",
             path=os.path.relpath(model_path, settings.model_path),
             hyperparameters=ranker.params,
-            metrics={k: float(v) for k, v in metrics.items() if isinstance(v, (int, float))},
+            metrics={
+                k: float(v) for k, v in metrics.items() if isinstance(v, (int, float))
+            },
             trained_at=datetime.now(timezone.utc),
             is_active=False,
             status="candidate",
         )
 
         registry = ModelRegistryService()
-        await registry.register_model(metadata)
+        model_id = await registry.register_model(metadata)
 
-        return metrics
+        result = dict(metrics)
+        result["model_id"] = model_id
+        return result

--- a/tests/recommender/training/test_reranker_lgbm_trainer.py
+++ b/tests/recommender/training/test_reranker_lgbm_trainer.py
@@ -10,14 +10,16 @@ _MODULE = "src.recommender.training.trainers.reranker_lgbm_trainer"
 
 def _make_grouped_df():
     """Minimal grouped DataFrame accepted by LGBMRanker."""
-    return pd.DataFrame({
-        "query_id": [0, 0, 1, 1],
-        "query_text": ["python", "python", "javascript", "javascript"],
-        "name": ["repo1", "repo2", "repo3", "repo4"],
-        "description": ["d1", "d2", "d3", "d4"],
-        "language": ["Python", "Python", "JavaScript", "JavaScript"],
-        "stars": [100, 50, 200, 10],
-    })
+    return pd.DataFrame(
+        {
+            "query_id": [0, 0, 1, 1],
+            "query_text": ["python", "python", "javascript", "javascript"],
+            "name": ["repo1", "repo2", "repo3", "repo4"],
+            "description": ["d1", "d2", "d3", "d4"],
+            "language": ["Python", "Python", "JavaScript", "JavaScript"],
+            "stars": [100, 50, 200, 10],
+        }
+    )
 
 
 def _make_mocks(metrics=None):
@@ -29,6 +31,7 @@ def _make_mocks(metrics=None):
 
     mock_registry = AsyncMock()
     mock_registry.register_model = AsyncMock()
+    mock_registry.register_model.return_value = "model-123"
 
     mock_settings = MagicMock()
     mock_settings.model_path = "/tmp/test-models"
@@ -36,20 +39,26 @@ def _make_mocks(metrics=None):
     return mock_ranker, mock_registry, mock_settings
 
 
-
 class TestRerankerLGBMTrainer:
     async def test_raises_when_grouped_df_missing(self):
-        from src.recommender.training.trainers.reranker_lgbm_trainer import RerankerLGBMTrainer
+        from src.recommender.training.trainers.reranker_lgbm_trainer import (
+            RerankerLGBMTrainer,
+        )
 
         trainer = RerankerLGBMTrainer()
         with pytest.raises(ValueError, match="grouped_df"):
             await trainer.train({}, variant="default")
 
     async def test_train_calls_lgbm_ranker_train(self):
-        from src.recommender.training.trainers.reranker_lgbm_trainer import RerankerLGBMTrainer
+        from src.recommender.training.trainers.reranker_lgbm_trainer import (
+            RerankerLGBMTrainer,
+        )
 
         mock_ranker, mock_registry, mock_settings = _make_mocks()
-        training_data = {"grouped_df": _make_grouped_df(), "dataset_version": "20260101-abc"}
+        training_data = {
+            "grouped_df": _make_grouped_df(),
+            "dataset_version": "20260101-abc",
+        }
 
         with (
             patch(f"{_MODULE}.LGBMRanker", return_value=mock_ranker),
@@ -61,7 +70,9 @@ class TestRerankerLGBMTrainer:
         mock_ranker.train.assert_called_once()
 
     async def test_train_saves_model(self):
-        from src.recommender.training.trainers.reranker_lgbm_trainer import RerankerLGBMTrainer
+        from src.recommender.training.trainers.reranker_lgbm_trainer import (
+            RerankerLGBMTrainer,
+        )
 
         mock_ranker, mock_registry, mock_settings = _make_mocks()
         training_data = {"grouped_df": _make_grouped_df()}
@@ -76,7 +87,9 @@ class TestRerankerLGBMTrainer:
         mock_ranker.save.assert_called_once()
 
     async def test_train_calls_registry_register_model(self):
-        from src.recommender.training.trainers.reranker_lgbm_trainer import RerankerLGBMTrainer
+        from src.recommender.training.trainers.reranker_lgbm_trainer import (
+            RerankerLGBMTrainer,
+        )
 
         mock_ranker, mock_registry, mock_settings = _make_mocks()
         training_data = {"grouped_df": _make_grouped_df()}
@@ -91,10 +104,14 @@ class TestRerankerLGBMTrainer:
         mock_registry.register_model.assert_awaited_once()
 
     async def test_train_returns_metrics(self):
-        from src.recommender.training.trainers.reranker_lgbm_trainer import RerankerLGBMTrainer
+        from src.recommender.training.trainers.reranker_lgbm_trainer import (
+            RerankerLGBMTrainer,
+        )
 
         expected_metrics = {"mean_ndcg_at_10": 0.85, "best_iteration": 200}
-        mock_ranker, mock_registry, mock_settings = _make_mocks(metrics=expected_metrics)
+        mock_ranker, mock_registry, mock_settings = _make_mocks(
+            metrics=expected_metrics
+        )
         training_data = {"grouped_df": _make_grouped_df()}
 
         with (
@@ -104,11 +121,13 @@ class TestRerankerLGBMTrainer:
         ):
             result = await RerankerLGBMTrainer().train(training_data, variant="default")
 
-        assert result == expected_metrics
+        assert result == {**expected_metrics, "model_id": "model-123"}
 
     async def test_train_propagates_lgbm_ranker_exception(self):
         """When LGBMRanker.train() raises, the exception propagates from the executor."""
-        from src.recommender.training.trainers.reranker_lgbm_trainer import RerankerLGBMTrainer
+        from src.recommender.training.trainers.reranker_lgbm_trainer import (
+            RerankerLGBMTrainer,
+        )
 
         mock_ranker, mock_registry, mock_settings = _make_mocks()
         mock_ranker.train.side_effect = ValueError("bad training data")


### PR DESCRIPTION
## Summary

This PR closes the three infrastructure/runtime gaps that were preventing the training stack from working end-to-end with automatic model activation in the deployed Docker environment.

---

## What Changed

### 1. Shared model artifact volume between training and recommender (Gap 1)

- Updated training service mount to use the same named volume as recommender: `docker-compose.training.yml:48`
- Confirmed recommender already uses the same volume: `docker-compose.app.yml:24`
- Confirmed shared volume exists in base compose (no code change required there): `docker-compose.base.yml:17`

**Impact:** `.pkl` model artifacts written by training are now visible to recommender at `/app/models`.

---

### 2. Default API_BASE_URL for training compose (Gap 2)

- Added fallback default: `docker-compose.training.yml:13`

**Impact:** Training no longer fails with missing `API_BASE_URL` when `.env` does not define it.

---

### 3. Automatic post-training promote + reload hooks (Gap 3)

- Added `RECOMMENDER_URL` env usage with default:
  - `docker-compose.training.yml:14`
  - `retrain_pipeline.py:67`

- After `RerankerLGBMPipeline.run()`, retrain now does sequential best-effort calls:
  - `POST /admin/models/promote/{model_id}`
  - `POST /admin/models/reload`
  - `retrain_pipeline.py:134`
  - `retrain_pipeline.py:138`

- Calls are explicitly non-fatal (warn + continue):
  - `retrain_pipeline.py:54`

- Ensured `model_id` is returned from the training pipeline result path:
  - `reranker_lgbm_trainer.py:94`
  - `reranker_lgbm_trainer.py:97`

**Impact:** Candidate model can be promoted and loaded without manual recommender restart.

---

## Testing Performed

### Compose wiring validation

- Rendered compose and verified effective values/mounts:
  - `API_BASE_URL=http://git-query-gateway`
  - `RECOMMENDER_URL=http://git-query-recommender:8095`
  - `model-artifacts -> /app/models`

### Python validation

- `py_compile` on modified training files:
  - `retrain_pipeline.py`
  - `reranker_lgbm_trainer.py`

### Targeted test runs

- `test_reranker_checkpointing.py`: passed  
- `test_registry_service.py`: passed (14 passed)  
- `test_recommender_api_integration.py` (targeted slices): no regressions in touched behavior path  

### E2E Docker run attempt

- Full stack/training run was executed.  
- **Result:** Run stopped before promote/reload due to empty runtime data (0 repos, unable to build query groups for LGBM).  

**Interpretation:** Wiring changes are functional; runtime proof of final promote/reload execution requires seeded training data in the environment.

---

## Acceptance Criteria Status

- Shared training/recommender model volume: **Done**  
- API_BASE_URL default in training compose: **Done**  
- RECOMMENDER_URL default in training compose: **Done**  
- Retrain promotes + reloads via recommender API: **Done (implemented)**  
- Post-training calls non-fatal: **Done**  
- Full end-to-end runtime verification: **Partially blocked by data availability (0 repos in environment)**

---
