### PR TITLE
feat(reranker): enhance model registration and loading with explicit …

### DIFF
--- a/src/recommender/services/registry_service.py
+++ b/src/recommender/services/registry_service.py
@@ -23,14 +23,18 @@ class ModelRegistryService:
     async def register_model(self, metadata: ModelMetadata) -> str:
         """Register a new model in the registry."""
         logger.info(
-            "Registering new model: %s (type: %s)", metadata.model_id, metadata.model_type
+            "Registering new model: %s (type: %s)",
+            metadata.model_id,
+            metadata.model_type,
         )
         await db_manager.save_model_metadata(metadata)
         return metadata.model_id
 
     async def get_active_model(
         self,
-        model_type: Literal["embedding", "cross_encoder", "personalization"],
+        model_type: Literal[
+            "embedding", "cross_encoder", "personalization", "reranker"
+        ],
         variant: str = "default",
     ) -> Optional[ModelMetadata]:
         """Get the currently active model for a specific type and variant."""

--- a/src/recommender/services/reranker_service.py
+++ b/src/recommender/services/reranker_service.py
@@ -31,6 +31,7 @@ class RerankerService:
         """Load the currently active reranker model from the registry."""
         async with self._load_lock:
             from .registry_service import ModelRegistryService
+
             registry = ModelRegistryService()
             # Prefer explicitly-typed cross_encoder entries, but also allow generic 'reranker' entries
             active_model = await registry.get_active_model("cross_encoder", variant)
@@ -48,21 +49,31 @@ class RerankerService:
                 return
 
             if active_model.model_id == self.current_model_id:
-                logger.info("Reranker model %s is already loaded.", active_model.model_id)
+                logger.info(
+                    "Reranker model %s is already loaded.", active_model.model_id
+                )
                 return
 
             # Load from path (prefer model files stored under settings.model_path)
-            full_path = os.path.join(settings.model_path, active_model.path) if getattr(active_model, 'path', None) else None
+            full_path = (
+                os.path.join(settings.model_path, active_model.path)
+                if getattr(active_model, "path", None)
+                else None
+            )
             loop = asyncio.get_running_loop()
             if full_path and os.path.exists(full_path):
-                logger.info("Loading active reranker model: %s from %s", active_model.model_id, full_path)
+                logger.info(
+                    "Loading active reranker model: %s from %s",
+                    active_model.model_id,
+                    full_path,
+                )
                 await loop.run_in_executor(None, self.load_model, full_path)
                 self.current_model_id = active_model.model_id
             else:
                 logger.warning(
                     "Active reranker model path not found on disk (model_id=%s, path=%s). Falling back to default: %s",
-                    getattr(active_model, 'model_id', None),
-                    getattr(active_model, 'path', None),
+                    getattr(active_model, "model_id", None),
+                    getattr(active_model, "path", None),
                     self.model_name,
                 )
                 await loop.run_in_executor(None, self.load_model, self.model_name)
@@ -89,8 +100,29 @@ class RerankerService:
 
         top_k = top_k or settings.rerank_top_k
 
+        if self._adapter is None:
+            logger.warning(
+                "Reranker adapter is not loaded. Attempting lazy load of default model: %s",
+                self.model_name,
+            )
+            loop = asyncio.get_running_loop()
+            loaded_adapter = await loop.run_in_executor(
+                None, self.load_model, self.model_name
+            )
+            if self._adapter is None and loaded_adapter is not None:
+                self._adapter = loaded_adapter
+                self.model = loaded_adapter
+                self._loaded_path = self.model_name
+
+        if self._adapter is None:
+            raise RuntimeError(
+                "Reranker adapter is unavailable after lazy load attempt"
+            )
+
         loop = asyncio.get_running_loop()
-        scores = await loop.run_in_executor(None, self._adapter.score, query, candidates)
+        scores = await loop.run_in_executor(
+            None, self._adapter.score, query, candidates
+        )
 
         for candidate, score in zip(candidates, scores):
             candidate.explanation = candidate.explanation or {}
@@ -105,4 +137,3 @@ class RerankerService:
             result.explanation["reranked"] = True
 
         return reranked[:top_k]
-

--- a/src/recommender/services/reranker_service.py
+++ b/src/recommender/services/reranker_service.py
@@ -101,18 +101,21 @@ class RerankerService:
         top_k = top_k or settings.rerank_top_k
 
         if self._adapter is None:
-            logger.warning(
-                "Reranker adapter is not loaded. Attempting lazy load of default model: %s",
-                self.model_name,
-            )
-            loop = asyncio.get_running_loop()
-            loaded_adapter = await loop.run_in_executor(
-                None, self.load_model, self.model_name
-            )
-            if self._adapter is None and loaded_adapter is not None:
-                self._adapter = loaded_adapter
-                self.model = loaded_adapter
-                self._loaded_path = self.model_name
+            async with self._load_lock:
+                # Double-check inside the lock — another coroutine may have already loaded
+                if self._adapter is None:
+                    logger.warning(
+                        "Reranker adapter is not loaded. Attempting lazy load of default model: %s",
+                        self.model_name,
+                    )
+                    loop = asyncio.get_running_loop()
+                    loaded_adapter = await loop.run_in_executor(
+                        None, self.load_model, self.model_name
+                    )
+                    if loaded_adapter is not None:
+                        self._adapter = loaded_adapter
+                        self.model = loaded_adapter
+                        self._loaded_path = self.model_name
 
         if self._adapter is None:
             raise RuntimeError(

--- a/src/recommender/training/pipelines/reranker_lgbm_pipeline.py
+++ b/src/recommender/training/pipelines/reranker_lgbm_pipeline.py
@@ -52,7 +52,7 @@ class RerankerLGBMPipeline(BasePipeline):
     async def train(self, training_data: Dict[str, Any]) -> Dict[str, Any]:
         from ..trainers.reranker_lgbm_trainer import RerankerLGBMTrainer
 
-        trainer = RerankerLGBMTrainer()
+        trainer = RerankerLGBMTrainer(model_dir=self.models_dir)
         return await trainer.train(
             training_data=training_data,
             variant=self.variant,
@@ -61,7 +61,9 @@ class RerankerLGBMPipeline(BasePipeline):
             tracker=self.tracker,
         )
 
-    async def evaluate(self, training_data: Dict[str, Any], metrics: Dict[str, Any]) -> Dict[str, Any]:
+    async def evaluate(
+        self, training_data: Dict[str, Any], metrics: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """NDCG evaluation is performed inside LGBMRanker.train() with multi-seed eval."""
         return metrics
 

--- a/src/recommender/training/retrain_pipeline.py
+++ b/src/recommender/training/retrain_pipeline.py
@@ -93,6 +93,8 @@ async def main() -> None:
     ).rstrip("/")
     qdrant_api_key = os.getenv("APIKEY_QDRANT", api_key)
     models_dir = os.getenv("MODELS_DIR", "/app/models")
+    # Keep config-driven trainers aligned with orchestrator model directory.
+    os.environ["MODEL_PATH"] = models_dir
     max_repos_env = os.getenv("MAX_REPOS")
     max_repos = int(max_repos_env) if max_repos_env else None
 

--- a/src/recommender/training/trainers/reranker_lgbm_trainer.py
+++ b/src/recommender/training/trainers/reranker_lgbm_trainer.py
@@ -20,8 +20,13 @@ class RerankerLGBMTrainer:
     with LGBMRanker's synchronous API.
     """
 
-    def __init__(self, params: Optional[Dict[str, Any]] = None):
+    def __init__(
+        self,
+        params: Optional[Dict[str, Any]] = None,
+        model_dir: Optional[str] = None,
+    ):
         self.params = params
+        self.model_dir = model_dir
 
     async def train(
         self,
@@ -72,7 +77,11 @@ class RerankerLGBMTrainer:
         # Save model artifact
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
         model_filename = f"lgbm_{variant}_{timestamp}.pkl"
-        model_path = os.path.join(settings.model_path, model_filename)
+        # Prefer explicit pipeline model_dir; fall back to env / static settings.
+        resolved_model_dir = (
+            self.model_dir or os.getenv("MODEL_PATH") or settings.model_path
+        )
+        model_path = os.path.join(resolved_model_dir, model_filename)
         await loop.run_in_executor(None, ranker.save, model_path)
         logger.info("LightGBM model saved to: %s", model_path)
 
@@ -82,7 +91,7 @@ class RerankerLGBMTrainer:
             model_type="reranker",
             variant=variant,
             version="1.0.0",
-            path=os.path.relpath(model_path, settings.model_path),
+            path=os.path.relpath(model_path, resolved_model_dir),
             hyperparameters=ranker.params,
             metrics={
                 k: float(v) for k, v in metrics.items() if isinstance(v, (int, float))

--- a/src/shared/config.py
+++ b/src/shared/config.py
@@ -1,5 +1,5 @@
 import os
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
 from typing import List, Optional
 
@@ -36,10 +36,10 @@ class Settings(BaseSettings):
 
     # API Keys
     # API keys - read from new environment variable names (preferred)
-    mongodb_api_key: Optional[str] = Field(None, env="APIKEY_MONGODB")
-    redis_api_key: Optional[str] = Field(None, env="APIKEY_REDIS")
-    qdrant_api_key: Optional[str] = Field(None, env="APIKEY_QDRANT")
-    mcp_api_key: Optional[str] = Field(None, env="APIKEY_MCP")
+    mongodb_api_key: Optional[str] = Field(None, validation_alias="APIKEY_MONGODB")
+    redis_api_key: Optional[str] = Field(None, validation_alias="APIKEY_REDIS")
+    qdrant_api_key: Optional[str] = Field(None, validation_alias="APIKEY_QDRANT")
+    mcp_api_key: Optional[str] = Field(None, validation_alias="APIKEY_MCP")
     # Cosmos support removed; no emulator API key
 
     # CORS - when using credentials, must specify exact origins (not "*")
@@ -50,9 +50,11 @@ class Settings(BaseSettings):
 
     # Admin seed user - created on gateway startup if not already present.
     # Set WEB_ADMIN_EMAIL (and the other two) to enable seeding.
-    web_admin_email: Optional[str] = Field(None, env="WEB_ADMIN_EMAIL")
-    web_admin_password: Optional[str] = Field(None, env="WEB_ADMIN_PASSWORD")
-    web_admin_username: str = Field("admin", env="WEB_ADMIN_USERNAME")
+    web_admin_email: Optional[str] = Field(None, validation_alias="WEB_ADMIN_EMAIL")
+    web_admin_password: Optional[str] = Field(
+        None, validation_alias="WEB_ADMIN_PASSWORD"
+    )
+    web_admin_username: str = Field("admin", validation_alias="WEB_ADMIN_USERNAME")
 
     # Rate limiting
     rate_limit_requests: int = 100
@@ -65,13 +67,14 @@ class Settings(BaseSettings):
     def allowed_origins_list(self) -> List[str]:
         return [origin.strip() for origin in self.allowed_origins.split(",")]
 
-    class Config:
+    model_config = SettingsConfigDict(
         # Check root .env first (Docker passes vars via environment, so the
         # path not existing is fine), then fall back to infrastructure/docker/.env
         # so local dev picks up credentials without needing a root-level .env.
-        env_file = (".env", _DOCKER_ENV)
-        env_prefix = ""
-        extra = "ignore"
+        env_file=(".env", _DOCKER_ENV),
+        env_prefix="",
+        extra="ignore",
+    )
 
 
 settings = Settings()

--- a/tests/recommender/test_embedding_service.py
+++ b/tests/recommender/test_embedding_service.py
@@ -10,6 +10,7 @@ Covers:
 
 import asyncio
 import inspect
+import os
 import numpy as np
 import pytest
 from datetime import datetime, timezone
@@ -19,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch, call
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_service(model_name: str = "fake-model"):
     """Return an EmbeddingService with a pre-wired mock model (no HuggingFace calls)."""
@@ -58,6 +60,7 @@ def _make_repo_result(**kwargs):
 # ===========================================================================
 # load_model
 # ===========================================================================
+
 
 class TestLoadModel:
     """Behaviour of EmbeddingService.load_model — specifically the _loaded_path guard."""
@@ -130,6 +133,7 @@ class TestLoadModel:
 # load_active_model
 # ===========================================================================
 
+
 class TestLoadActiveModel:
     """Behaviour of EmbeddingService.load_active_model — registry integration."""
 
@@ -189,13 +193,17 @@ class TestLoadActiveModel:
         mock_registry = AsyncMock()
         mock_registry.get_active_model.return_value = active
 
-        full_path = f"{settings.model_path}/{active.path}"
+        full_path = os.path.join(settings.model_path, active.path)
 
         with patch(
             "src.recommender.services.registry_service.ModelRegistryService",
             return_value=mock_registry,
-        ), patch("src.recommender.services.embedding_service.os.path.exists", return_value=True), \
-                patch.object(svc, "load_model") as mock_load:
+        ), patch(
+            "src.recommender.services.embedding_service.os.path.exists",
+            return_value=True,
+        ), patch.object(
+            svc, "load_model"
+        ) as mock_load:
             await svc.load_active_model()
 
         mock_load.assert_called_once_with(full_path)
@@ -219,8 +227,12 @@ class TestLoadActiveModel:
         with patch(
             "src.recommender.services.registry_service.ModelRegistryService",
             return_value=mock_registry,
-        ), patch("src.recommender.services.embedding_service.os.path.exists", return_value=False), \
-                patch.object(svc, "load_model") as mock_load:
+        ), patch(
+            "src.recommender.services.embedding_service.os.path.exists",
+            return_value=False,
+        ), patch.object(
+            svc, "load_model"
+        ) as mock_load:
             await svc.load_active_model()
 
         mock_load.assert_called_once_with("default-embed-model")
@@ -231,6 +243,7 @@ class TestLoadActiveModel:
 # ===========================================================================
 # embed_text
 # ===========================================================================
+
 
 class TestEmbedText:
     """Behaviour of EmbeddingService.embed_text."""
@@ -272,6 +285,7 @@ class TestEmbedText:
 # embed_batch
 # ===========================================================================
 
+
 class TestEmbedBatch:
     """Behaviour of EmbeddingService.embed_batch."""
 
@@ -306,6 +320,7 @@ class TestEmbedBatch:
 # ===========================================================================
 # get_dimension
 # ===========================================================================
+
 
 class TestGetDimension:
     """Behaviour of EmbeddingService.get_dimension."""

--- a/tests/recommender/test_reranker_service.py
+++ b/tests/recommender/test_reranker_service.py
@@ -7,6 +7,7 @@ Covers:
 """
 
 import pytest
+import os
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -14,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_service(model_name: str = "fake-cross-encoder"):
     """Return a RerankerService with a pre-wired mock adapter (no real model loading)."""
@@ -53,6 +55,7 @@ def _make_repo_result(repo_id: str, score: float, rank: int = 1, **kwargs):
 # ===========================================================================
 # load_model
 # ===========================================================================
+
 
 class TestLoadModel:
     """Behaviour of RerankerService.load_model — delegates to AdapterFactory."""
@@ -125,6 +128,7 @@ class TestLoadModel:
 # load_active_model
 # ===========================================================================
 
+
 class TestLoadActiveModel:
     """Behaviour of RerankerService.load_active_model — registry integration."""
 
@@ -182,13 +186,17 @@ class TestLoadActiveModel:
         mock_registry = AsyncMock()
         mock_registry.get_active_model.return_value = active
 
-        full_path = f"{settings.model_path}/{active.path}"
+        full_path = os.path.join(settings.model_path, active.path)
 
         with patch(
             "src.recommender.services.registry_service.ModelRegistryService",
             return_value=mock_registry,
-        ), patch("src.recommender.services.reranker_service.os.path.exists", return_value=True), \
-                patch.object(svc, "load_model") as mock_load:
+        ), patch(
+            "src.recommender.services.reranker_service.os.path.exists",
+            return_value=True,
+        ), patch.object(
+            svc, "load_model"
+        ) as mock_load:
             await svc.load_active_model()
 
         mock_load.assert_called_once_with(full_path)
@@ -212,8 +220,12 @@ class TestLoadActiveModel:
         with patch(
             "src.recommender.services.registry_service.ModelRegistryService",
             return_value=mock_registry,
-        ), patch("src.recommender.services.reranker_service.os.path.exists", return_value=False), \
-                patch.object(svc, "load_model") as mock_load:
+        ), patch(
+            "src.recommender.services.reranker_service.os.path.exists",
+            return_value=False,
+        ), patch.object(
+            svc, "load_model"
+        ) as mock_load:
             await svc.load_active_model()
 
         mock_load.assert_called_once_with("default-cross-encoder")
@@ -225,8 +237,26 @@ class TestLoadActiveModel:
 # rerank
 # ===========================================================================
 
+
 class TestRerank:
     """Behaviour of RerankerService.rerank."""
+
+    @pytest.mark.asyncio
+    async def test_rerank_lazy_loads_adapter_when_missing(self):
+        """If adapter is missing, service loads default model before scoring."""
+        from src.recommender.services.reranker_service import RerankerService
+
+        svc = RerankerService(model_name="default-cross-encoder")
+        svc._adapter = None
+        candidates = [_make_repo_result("r1", score=0.2)]
+
+        mock_adapter = MagicMock()
+        mock_adapter.score.return_value = [0.9]
+        with patch.object(svc, "load_model", return_value=mock_adapter) as mock_load:
+            result = await svc.rerank("query", candidates, top_k=1)
+
+        mock_load.assert_called_once_with("default-cross-encoder")
+        assert result[0].score == pytest.approx(0.9)
 
     @pytest.mark.asyncio
     async def test_rerank_returns_empty_for_empty_candidates(self):
@@ -253,9 +283,9 @@ class TestRerank:
         """Returned list is ordered highest score first."""
         svc, mock_adapter = _make_service()
         candidates = [
-            _make_repo_result("low",  score=0.1),
+            _make_repo_result("low", score=0.1),
             _make_repo_result("high", score=0.9),
-            _make_repo_result("mid",  score=0.5),
+            _make_repo_result("mid", score=0.5),
         ]
         mock_adapter.score.return_value = [0.1, 0.9, 0.5]
 
@@ -329,5 +359,3 @@ class TestRerank:
         result = await svc.rerank("query", candidates)  # no top_k argument
 
         assert len(result) <= settings.rerank_top_k
-
-

--- a/tests/recommender/training/test_reranker_lgbm_trainer.py
+++ b/tests/recommender/training/test_reranker_lgbm_trainer.py
@@ -86,6 +86,27 @@ class TestRerankerLGBMTrainer:
 
         mock_ranker.save.assert_called_once()
 
+    async def test_train_uses_explicit_model_dir_when_provided(self):
+        from src.recommender.training.trainers.reranker_lgbm_trainer import (
+            RerankerLGBMTrainer,
+        )
+
+        mock_ranker, mock_registry, mock_settings = _make_mocks()
+        training_data = {"grouped_df": _make_grouped_df()}
+
+        with (
+            patch(f"{_MODULE}.LGBMRanker", return_value=mock_ranker),
+            patch(f"{_MODULE}.ModelRegistryService", return_value=mock_registry),
+            patch(f"{_MODULE}.settings", mock_settings),
+        ):
+            await RerankerLGBMTrainer(model_dir="/tmp/explicit-model-dir").train(
+                training_data,
+                variant="default",
+            )
+
+        save_path = mock_ranker.save.call_args.args[0]
+        assert save_path.startswith("/tmp/explicit-model-dir")
+
     async def test_train_calls_registry_register_model(self):
         from src.recommender.training.trainers.reranker_lgbm_trainer import (
             RerankerLGBMTrainer,


### PR DESCRIPTION
Summary
This PR improves reliability and cross-platform consistency in the recommender stack, with a focus on reranker robustness, model artifact path handling, and config modernization.

What Changed
Reranker reliability hardening
Added lazy-load guard in reranking so missing adapters are initialized before scoring.
Preserved safe failure behavior if adapter remains unavailable.
Updated registry typing to explicitly include reranker model type.
Training/model path consistency
Propagated pipeline [models_dir](vscode-file://vscode-app/c:/Users/hugok/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) into the LightGBM reranker trainer.
Ensured trainer saves artifacts and computes registry-relative paths using the resolved model directory.
Synced retraining orchestration (MODELS_DIR) with MODEL_PATH to avoid path drift between pipeline and settings-based components.
Cross-platform test stability
Fixed path assertions in tests to use OS-aware joining ([os.path.join](vscode-file://vscode-app/c:/Users/hugok/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) instead of slash-only string concatenation.
Pydantic v2 deprecation cleanup (shared config)
Replaced deprecated [Field(..., env=...)](vscode-file://vscode-app/c:/Users/hugok/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) usage with [validation_alias](vscode-file://vscode-app/c:/Users/hugok/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Replaced deprecated class-based Config with [SettingsConfigDict](vscode-file://vscode-app/c:/Users/hugok/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Validation
Focused reranker tests: passed.
Broader recommender suite: 254 passed, 0 failed.
Warning count reduced; remaining warnings come from external FastAPI internals, not project code.
Impact
Safer runtime behavior during reranker inference.
Fewer environment/path surprises across local, Docker, and Windows/Linux.
Cleaner forward-compatible config code with Pydantic v2.
Notes
No API contract changes expected.
Changes are backward-compatible with existing model registry records and active model flows.
GPT-5.3-Codex • 1x