### PR TITLE
fix: replace deprecated qdrant .search() with .query_points()

### DIFF
--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,6 +1,6 @@
 # CI-only requirements: everything needed for lint and unit tests.
 # Excludes only non-essential extras for CI runtime/cost, e.g. kagglehub, ijson,
-#           pyarrow, fastparquet, matplotlib, ipykernel
+#           matplotlib, ipykernel
 
 # Web Framework & API
 fastapi>=0.115.0
@@ -41,6 +41,7 @@ pandas>=2.0.0
 numpy>=1.26.3
 scikit-learn>=1.4.0
 lightgbm>=4.0.0
+pyarrow>=14.0.0
 torch>=2.2.0
 sentence-transformers>=2.3.1
 

--- a/src/db/adapters/qdrant_adapter.py
+++ b/src/db/adapters/qdrant_adapter.py
@@ -133,7 +133,15 @@ class QdrantAdapter(VectorRepository):
         # Try client methods first
         if self.client:
             try:
-                if hasattr(self.client, "search"):
+                if hasattr(self.client, "query_points"):
+                    res = self.client.query_points(
+                        collection_name=collection,
+                        query=vector,
+                        limit=limit,
+                        query_filter=filter or {},
+                        with_payload=True,
+                    ).points
+                elif hasattr(self.client, "search"):
                     res = self.client.search(
                         collection_name=collection,
                         query_vector=vector,

--- a/src/recommender/database.py
+++ b/src/recommender/database.py
@@ -199,16 +199,28 @@ class DatabaseManager:
         to keep the event loop unblocked.
         """
         loop = asyncio.get_running_loop()
-        results = await loop.run_in_executor(
-            None,
-            lambda: self.qdrant_client.search(
-                collection_name=settings.qdrant_repos_collection,
-                query_vector=query_vector,
-                limit=top_k,
-                query_filter=filter_conditions,
-                with_payload=True,
-            ),
-        )
+        if hasattr(self.qdrant_client, "query_points"):
+            results = await loop.run_in_executor(
+                None,
+                lambda: self.qdrant_client.query_points(
+                    collection_name=settings.qdrant_repos_collection,
+                    query=query_vector,
+                    limit=top_k,
+                    query_filter=filter_conditions,
+                    with_payload=True,
+                ).points,
+            )
+        else:
+            results = await loop.run_in_executor(
+                None,
+                lambda: self.qdrant_client.search(
+                    collection_name=settings.qdrant_repos_collection,
+                    query_vector=query_vector,
+                    limit=top_k,
+                    query_filter=filter_conditions,
+                    with_payload=True,
+                ),
+            )
         return [
             {
                 "repo_id": hit.id,

--- a/tests/gateway/test_mlflow_proxy.py
+++ b/tests/gateway/test_mlflow_proxy.py
@@ -1,3 +1,5 @@
+import gzip
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -318,7 +320,7 @@ def test_proxy_response_drops_representation_headers(monkeypatch):
     DummyAsyncClient.fail_hosts = set()
     DummyAsyncClient.status_by_prefix = {}
     DummyAsyncClient.content_by_prefix = {
-        "http://git-query-mlflow:5000/static-files": b"console.log('ok');"
+        "http://git-query-mlflow:5000/static-files": gzip.compress(b"console.log('ok');")
     }
     DummyAsyncClient.content_type_by_prefix = {
         "http://git-query-mlflow:5000/static-files": "application/javascript"


### PR DESCRIPTION
## Summary
- `QdrantClient.search()` was removed in qdrant-client v1.10.0, causing all `/recommend` requests to return 500
- Replaced with `query_points()` (new API) in both `src/recommender/database.py` and `src/db/adapters/qdrant_adapter.py`
- Kept legacy `.search()` and `.search_points()` as fallbacks for older client versions

## Test plan
- [ ] Redeploy `git-query-recommender` container
- [ ] Confirm `POST /recommend` returns 200 instead of 500