### PR TITLE
fix: degrade gracefully when reranker fails

### DIFF
--- a/src/recommender/engines/hybrid.py
+++ b/src/recommender/engines/hybrid.py
@@ -3,11 +3,14 @@
 import asyncio
 import hashlib
 import json
+import logging
 from typing import List, Dict, Any, Set
 from ..models import RecommendationRequest, RepositoryResult
 from ..database import db_manager
 from ..config import settings
 from .base import RecommendationEngine
+
+logger = logging.getLogger(__name__)
 
 
 class HybridRetrievalEngine(RecommendationEngine):
@@ -63,7 +66,7 @@ class HybridRetrievalEngine(RecommendationEngine):
                     top_k=settings.rerank_top_k,
                 )
                 filtered_results = reranked + filtered_results[settings.hybrid_search_top_k :]
-            except RuntimeError as e:
+            except Exception as e:
                 logger.warning("Reranker unavailable, skipping rerank step: %s", e)
 
         # Step 5: Return top K


### PR DESCRIPTION
## Summary
- Reranker was catching only `RuntimeError`, letting LightGBM feature mismatch errors bubble up and crash the entire `/recommend` request
- Changed to `except Exception` so any reranker failure falls back to the pre-rerank retrieval order
- Added missing `logger` import that would have caused a `NameError` on the warning log

## Test plan
- [ ] Merge and redeploy recommender
- [ ] Confirm `POST /recommend` returns 200 with semantic+keyword results even when reranker model has a feature mismatch