### PR TITLE
fix: LGBM feature reindex, cross-encoder fallback, language vocab, vectors_count

### DIFF
--- a/src/recommender/data/features.py
+++ b/src/recommender/data/features.py
@@ -285,13 +285,17 @@ class FeatureExtractor:
     def language_encoded(
         df: pd.DataFrame,
         top_n: int = TOP_N_LANGUAGES,
+        fixed_languages: Optional[List[str]] = None,
     ) -> pd.DataFrame:
         """One-hot encode the primary language column.
 
-        The *top_n* most frequent languages each get their own binary column
-        (``lang_python``, ``lang_javascript``, ...).  All remaining languages
-        are grouped into ``lang_other``.  Missing values map to
-        ``lang_other``.
+        If *fixed_languages* is provided (e.g. the vocabulary saved at training
+        time), it is used directly instead of computing top-N from *df*.  This
+        ensures training and inference produce identical columns.
+
+        Otherwise the *top_n* most frequent languages in *df* each get their
+        own binary column.  All remaining languages are grouped into
+        ``lang_other``.  Missing values map to ``lang_other``.
 
         Returns:
             DataFrame with up to ``top_n + 1`` boolean (int) columns.
@@ -300,13 +304,15 @@ class FeatureExtractor:
 
         lang = df["language"].fillna("other").astype(str).str.strip().str.lower()
 
-        top_languages = lang.value_counts().head(top_n).index.tolist()
-        lang = lang.where(lang.isin(top_languages), other="other")
+        if fixed_languages is not None:
+            known = set(fixed_languages)
+        else:
+            known = set(lang.value_counts().head(top_n).index.tolist())
+
+        lang = lang.where(lang.isin(known), other="other")
 
         dummies = _pd.get_dummies(lang, prefix="lang", dtype=int)
 
-        # Ensure ``lang_other`` always exists even if every repo has a
-        # top-N language.
         if "lang_other" not in dummies.columns:
             dummies["lang_other"] = 0
 
@@ -392,6 +398,7 @@ class FeatureExtractor:
         self,
         df: pd.DataFrame,
         query: Optional[str] = None,
+        fixed_languages: Optional[List[str]] = None,
     ) -> pd.DataFrame:
         """Extract all numeric features into a single DataFrame.
 
@@ -420,7 +427,7 @@ class FeatureExtractor:
             self.description_length(df),
             self.has_license(df),
             self.is_permissive_license(df),
-            self.language_encoded(df),
+            self.language_encoded(df, fixed_languages=fixed_languages),
         ]
 
         if query:

--- a/src/recommender/services/adapters/lgbm_adapter.py
+++ b/src/recommender/services/adapters/lgbm_adapter.py
@@ -50,8 +50,5 @@ class LGBMAdapter(BaseRerankerAdapter):
         df = pd.DataFrame(rows)
         X = self._fe.extract_all(df, query=query)
         if self._feature_cols is not None:
-            try:
-                X = X[self._feature_cols]
-            except KeyError as e:
-                logger.warning("Feature column filter failed, using all features: %s", e)
+            X = X.reindex(columns=self._feature_cols, fill_value=0)
         return self._model.predict(X.values).tolist()

--- a/src/recommender/services/adapters/lgbm_adapter.py
+++ b/src/recommender/services/adapters/lgbm_adapter.py
@@ -25,9 +25,11 @@ class LGBMAdapter(BaseRerankerAdapter):
         if isinstance(payload, dict):
             self._model = payload["model"]
             self._feature_cols = payload.get("feature_cols")
+            self._language_vocab = payload.get("language_vocab")
         else:
             self._model = payload
             self._feature_cols = getattr(payload, "feature_cols", None)
+            self._language_vocab = getattr(payload, "language_vocab", None)
         self._fe = FeatureExtractor()
 
     def score(self, query: str, candidates: list) -> List[float]:
@@ -48,7 +50,7 @@ class LGBMAdapter(BaseRerankerAdapter):
                 }
             )
         df = pd.DataFrame(rows)
-        X = self._fe.extract_all(df, query=query)
+        X = self._fe.extract_all(df, query=query, fixed_languages=self._language_vocab)
         if self._feature_cols is not None:
             X = X.reindex(columns=self._feature_cols, fill_value=0)
         return self._model.predict(X.values).tolist()

--- a/src/recommender/services/reranker_service.py
+++ b/src/recommender/services/reranker_service.py
@@ -115,7 +115,15 @@ class RerankerService:
             raise RuntimeError("Reranker adapter is unavailable after lazy load attempt")
 
         loop = asyncio.get_running_loop()
-        scores = await loop.run_in_executor(None, self._adapter.score, query, candidates)
+        try:
+            scores = await loop.run_in_executor(None, self._adapter.score, query, candidates)
+        except Exception as e:
+            if self._loaded_path != self.model_name:
+                logger.warning("Primary reranker failed (%s), falling back to cross-encoder: %s", self._loaded_path, e)
+                fallback_adapter = await loop.run_in_executor(None, self.load_model, self.model_name)
+                scores = await loop.run_in_executor(None, fallback_adapter.score, query, candidates)
+            else:
+                raise
 
         for candidate, score in zip(candidates, scores):
             candidate.explanation = candidate.explanation or {}

--- a/src/recommender/training/lgbm_ranker.py
+++ b/src/recommender/training/lgbm_ranker.py
@@ -168,6 +168,7 @@ class LGBMRanker:
         self.params: dict[str, Any] = {**DEFAULT_PARAMS, **(params or {})}
         self.model = None
         self.feature_cols: list[str] | None = None
+        self.language_vocab: list[str] | None = None
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -329,6 +330,7 @@ class LGBMRanker:
         # Build full feature matrix to discover feature columns
         X_all, y_all, groups_all = self._build_rank_data(grouped_df, feature_extractor)
         self.feature_cols = X_all.columns.tolist()
+        self.language_vocab = [c[len("lang_"):] for c in self.feature_cols if c.startswith("lang_") and c != "lang_other"]
 
         unique_qids = np.array(sorted(grouped_df["query_id"].unique()))
 
@@ -471,7 +473,7 @@ class LGBMRanker:
 
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {"model": self.model, "feature_cols": self.feature_cols, "params": self.params}
+        payload = {"model": self.model, "feature_cols": self.feature_cols, "language_vocab": self.language_vocab, "params": self.params}
         joblib.dump(payload, path)
         logger.info("LGBMRanker saved to %s", path)
         return str(path)
@@ -490,6 +492,7 @@ class LGBMRanker:
         ranker = cls(params=payload.get("params"))
         ranker.model = payload["model"]
         ranker.feature_cols = payload["feature_cols"]
+        ranker.language_vocab = payload.get("language_vocab")
         logger.info("LGBMRanker loaded from %s (%d features)", path, len(ranker.feature_cols))
         return ranker
 

--- a/src/storage/routers/qdrant_router.py
+++ b/src/storage/routers/qdrant_router.py
@@ -95,8 +95,8 @@ async def list_qdrant_collections():
             name = getattr(col, "name", None) or getattr(col, "collection_name", "") or str(col)
             try:
                 info = qdrant_client.get_collection(name)
-                vectors_count = getattr(info, "vectors_count", None) or 0
                 points_count = getattr(info, "points_count", None) or 0
+                vectors_count = points_count
                 items.append({"name": name, "vectors_count": vectors_count, "points_count": points_count})
             except Exception:
                 items.append({"name": name, "vectors_count": 0, "points_count": 0})


### PR DESCRIPTION
## Summary
- `lgbm_adapter.py`: use `reindex` with zero-fill instead of crashing on feature column mismatch
- `reranker_service.py`: fall back to cross-encoder when LGBM scoring fails at inference
- `qdrant_router.py`: report `points_count` as `vectors_count` (we use unnamed default vectors)
- `features.py` + `lgbm_ranker.py` + `lgbm_adapter.py`: store language vocabulary in model pkl at training time and use fixed vocab at inference — same approach as sklearn's `OneHotEncoder.categories_`

## Test plan
- [ ] Merge and redeploy recommender
- [ ] Confirm `/recommend` returns results with LGBM reranking
- [ ] Retrain LGBM to pick up the new `language_vocab` field in pkl
- [ ] Confirm `/api/qdrant/collections` shows correct point counts