### PR TITLE
implement message normalization and rendering for chat functionality

### DIFF
--- a/web/public/src/home.js
+++ b/web/public/src/home.js
@@ -85,6 +85,85 @@ document.addEventListener('DOMContentLoaded', () => {
         return headers;
     }
 
+    function normalizeMessageRole(rawRole) {
+        const role = String(rawRole || '').toLowerCase();
+        if (role === 'assistant' || role === 'bot' || role === 'ai' || role === 'system') {
+            return 'assistant';
+        }
+        return 'user';
+    }
+
+    function normalizeMessageContent(rawMessage) {
+        if (typeof rawMessage === 'string') {
+            return rawMessage;
+        }
+        if (rawMessage == null) {
+            return '';
+        }
+        if (typeof rawMessage === 'object') {
+            const direct = rawMessage.content ?? rawMessage.text ?? rawMessage.message ?? rawMessage.body;
+            if (typeof direct === 'string') {
+                return direct;
+            }
+            if (Array.isArray(direct)) {
+                return direct
+                    .map(part => (typeof part === 'string' ? part : (part && typeof part === 'object' ? String(part.text || part.content || '') : '')))
+                    .filter(Boolean)
+                    .join('\n');
+            }
+            return String(direct ?? '');
+        }
+        return String(rawMessage);
+    }
+
+    function normalizeChatMessage(rawMessage) {
+        if (typeof rawMessage === 'string') {
+            return { content: rawMessage, role: 'assistant', timestamp: Date.now() };
+        }
+
+        const msg = rawMessage && typeof rawMessage === 'object' ? rawMessage : {};
+        const rawTimestamp = Number(msg.timestamp);
+        return {
+            content: normalizeMessageContent(msg),
+            role: normalizeMessageRole(msg.role ?? msg.type ?? msg.sender),
+            timestamp: Number.isFinite(rawTimestamp) ? rawTimestamp : Date.now(),
+        };
+    }
+
+    function normalizeChatSession(rawChat, index = 0) {
+        const chat = rawChat && typeof rawChat === 'object' ? rawChat : {};
+        const rawMessages = Array.isArray(chat.messages)
+            ? chat.messages
+            : Array.isArray(chat.history)
+                ? chat.history
+                : [];
+        const messages = rawMessages.map(normalizeChatMessage).filter(msg => msg.content || msg.role === 'assistant');
+        const fallbackTitle = messages.find(m => m.role === 'assistant')?.content || messages[0]?.content || 'New Session';
+        const rawTimestamp = Number(chat.timestamp ?? chat.updated_at ?? chat.created_at);
+
+        return {
+            id: String(chat.id ?? chat.chat_id ?? chat.session_id ?? `chat-${Date.now()}-${index}`),
+            title: String(chat.title ?? chat.name ?? fallbackTitle).slice(0, 120) || 'New Session',
+            timestamp: Number.isFinite(rawTimestamp) ? rawTimestamp : Date.now(),
+            messages,
+        };
+    }
+
+    function renderAssistantMarkdown(targetEl, text) {
+        const safeText = String(text ?? '');
+        if (typeof marked === 'undefined') {
+            targetEl.textContent = safeText;
+            return;
+        }
+
+        try {
+            targetEl.innerHTML = marked.parse(safeText);
+        } catch (error) {
+            console.warn('Falling back to plain text chat rendering:', error);
+            targetEl.textContent = safeText;
+        }
+    }
+
     async function persistChatsToBackend() {
         try {
             await fetch(`${API_BASE}/user/chats`, {
@@ -394,11 +473,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Text part
         const textEl = document.createElement('div');
-        if (typeof marked !== 'undefined') {
-            textEl.innerHTML = marked.parse(text);
-        } else {
-            textEl.textContent = text;
-        }
+        renderAssistantMarkdown(textEl, text);
         contentWrapper.appendChild(textEl);
 
         // Top-3 repo cards
@@ -558,10 +633,10 @@ document.addEventListener('DOMContentLoaded', () => {
         
         const content = document.createElement('div');
         content.className = 'message-content';
-        if (type === 'assistant' && typeof marked !== 'undefined') {
-            content.innerHTML = marked.parse(text);
+        if (type === 'assistant') {
+            renderAssistantMarkdown(content, text);
         } else {
-            content.textContent = text;
+            content.textContent = String(text ?? '');
         }
         
         messageDiv.appendChild(avatar);
@@ -579,14 +654,26 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Save chat message
     function saveChatMessage(chatId, text, type) {
-        const chat = chats.find(c => c.id === chatId);
-        if (chat) {
-            if (!chat.messages) {
-                chat.messages = [];
-            }
-            chat.messages.push({ content: text, role: type, timestamp: Date.now() });
-            void persistChatsToBackend();
+        const normalizedChatId = String(chatId);
+        let chat = chats.find(c => String(c.id) === normalizedChatId);
+
+        // Ensure first message of a new chat is not dropped.
+        if (!chat) {
+            chat = {
+                id: normalizedChatId,
+                title: 'New Session',
+                timestamp: Date.now(),
+                messages: []
+            };
+            chats.unshift(chat);
+            renderChatHistory();
         }
+
+        if (!Array.isArray(chat.messages)) {
+            chat.messages = [];
+        }
+        chat.messages.push({ content: String(text ?? ''), role: type, timestamp: Date.now() });
+        void persistChatsToBackend();
     }
     
     // Load chat history
@@ -600,7 +687,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (response.ok) {
                 const data = await response.json();
-                chats = Array.isArray(data.chats) ? data.chats : [];
+                const fetchedChats = Array.isArray(data.chats) ? data.chats : [];
+                chats = fetchedChats.map((chat, idx) => normalizeChatSession(chat, idx));
             } else {
                 chats = [];
             }
@@ -609,7 +697,10 @@ document.addEventListener('DOMContentLoaded', () => {
             if (chats.length === 0) {
                 const saved = localStorage.getItem('chats');
                 if (saved) {
-                    chats = JSON.parse(saved) || [];
+                    const parsed = JSON.parse(saved) || [];
+                    chats = Array.isArray(parsed)
+                        ? parsed.map((chat, idx) => normalizeChatSession(chat, idx))
+                        : [];
                     if (Array.isArray(chats) && chats.length > 0) {
                         await persistChatsToBackend();
                     }
@@ -661,7 +752,7 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             
             chatItem.addEventListener('click', () => {
-                loadChat(chat.id);
+                loadChat(String(chat.id));
             });
             
             chatHistory.appendChild(chatItem);
@@ -670,11 +761,23 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Update chat history
     function updateChatHistory(chatId, firstMessage) {
-        const existingChat = chats.find(c => c.id === chatId);
+        const normalizedChatId = String(chatId);
+        const existingChat = chats.find(c => String(c.id) === normalizedChatId);
+        const computedTitle = String(firstMessage ?? '').substring(0, 30) + (String(firstMessage ?? '').length > 30 ? '...' : '');
+
+        if (existingChat) {
+            if (!existingChat.title || existingChat.title === 'New Session') {
+                existingChat.title = computedTitle || 'New Session';
+                void persistChatsToBackend();
+                renderChatHistory();
+            }
+            return;
+        }
+
         if (!existingChat) {
             const newChat = {
-                id: chatId,
-                title: firstMessage.substring(0, 30) + (firstMessage.length > 30 ? '...' : ''),
+                id: normalizedChatId,
+                title: computedTitle || 'New Session',
                 timestamp: Date.now(),
                 messages: []
             };
@@ -716,10 +819,10 @@ document.addEventListener('DOMContentLoaded', () => {
     // Load specific chat
     async function loadChat(chatId) {
         try {
-            const chat = chats.find(c => c.id === chatId);
+            const chat = chats.find(c => String(c.id) === String(chatId));
             if (!chat) return;
             
-            currentChatId = chatId;
+            currentChatId = String(chat.id);
             messagesContainer.innerHTML = '';
             welcomeScreen.style.display = 'none';
             repoRecommendations.style.display = 'none';
@@ -727,8 +830,11 @@ document.addEventListener('DOMContentLoaded', () => {
             currentView = 'chat';
             
             // Load messages from saved chat
-            if (chat.messages && chat.messages.length > 0) {
-                chat.messages.forEach(msg => {
+            const normalizedMessages = Array.isArray(chat.messages)
+                ? chat.messages.map(normalizeChatMessage)
+                : [];
+            if (normalizedMessages.length > 0) {
+                normalizedMessages.forEach(msg => {
                     const messageDiv = document.createElement('div');
                     messageDiv.className = `message ${msg.role}`;
                     
@@ -738,10 +844,10 @@ document.addEventListener('DOMContentLoaded', () => {
                     
                     const content = document.createElement('div');
                     content.className = 'message-content';
-                    if (msg.role === 'assistant' && typeof marked !== 'undefined') {
-                        content.innerHTML = marked.parse(msg.content);
+                    if (msg.role === 'assistant') {
+                        renderAssistantMarkdown(content, msg.content);
                     } else {
-                        content.textContent = msg.content;
+                        content.textContent = String(msg.content ?? '');
                     }
                     
                     messageDiv.appendChild(avatar);


### PR DESCRIPTION
This PR fixes a Web UI issue where selecting an older chat sometimes did not load any messages.

Root Cause

Older chat payloads were not always in the exact shape expected by the UI loader and renderer.
Chat/message id and field shape differences (legacy vs current) could cause lookup or render failures.
First messages in a new chat could be dropped before the chat session object was created in memory.
What Changed

Added defensive normalization for chat sessions and messages before rendering.
Added safer role/content/timestamp handling for legacy message formats.
Hardened assistant markdown rendering with fallback to plain text to avoid render aborts.
Made chat id matching robust across string/number differences.
Fixed message persistence ordering so the first chat messages are never dropped.
Updated chat history title behavior so placeholder titles are replaced when first assistant response arrives.
Validation

JavaScript syntax check passed for the updated Web UI script.
Targeted gateway user service tests passed: 7 passed.
Full router test collection is currently blocked in local environment by missing argon2 dependency.
Impact

Older chats now load more reliably from persisted data.
Chat history is more resilient to legacy payloads and malformed content.
Reduced chance of silent empty-chat regressions in the UI.
