### PR TITLE
fix: override GPU reservation for CPU-only server in retrain workflows

### DIFF
--- a/.github/workflows/manual-generate-synthetic-interactions.yml
+++ b/.github/workflows/manual-generate-synthetic-interactions.yml
@@ -113,11 +113,21 @@ jobs:
           REPO_PATH="/home/$HETZNER_USER/git-query"
           cd "\$REPO_PATH"
 
+          cat > "\$REPO_PATH/.runtime/docker-compose.training-cpu.yml" << 'EOF'
+          services:
+            training:
+              deploy:
+                resources:
+                  reservations:
+                    devices: []
+          EOF
+
           echo "Triggering LGBM-only retraining via docker-compose..."
           docker compose \
             -f infrastructure/docker/docker-compose.base.yml \
             -f infrastructure/docker/docker-compose.mlflow.yml \
             -f infrastructure/docker/docker-compose.training.yml \
+            -f .runtime/docker-compose.training-cpu.yml \
             --env-file .env \
             run --rm -e ENABLE_EMBEDDING_TRAINING=false training
 

--- a/.github/workflows/manual-retrain-lgbm.yml
+++ b/.github/workflows/manual-retrain-lgbm.yml
@@ -58,11 +58,21 @@ jobs:
           echo "Building training image..."
           docker build -f infrastructure/docker/Dockerfile.training -t git-query-training .
 
+          cat > "\$REPO_PATH/.runtime/docker-compose.training-cpu.yml" << 'EOF'
+          services:
+            training:
+              deploy:
+                resources:
+                  reservations:
+                    devices: []
+          EOF
+
           echo "Triggering LGBM-only retraining via docker-compose..."
           docker compose \
             -f infrastructure/docker/docker-compose.base.yml \
             -f infrastructure/docker/docker-compose.mlflow.yml \
             -f infrastructure/docker/docker-compose.training.yml \
+            -f .runtime/docker-compose.training-cpu.yml \
             --env-file .env \
             run --rm -e ENABLE_EMBEDDING_TRAINING=false training
 


### PR DESCRIPTION
The training compose file has an nvidia GPU reservation that fails on the Hetzner server which has no GPU. Adds an inline CPU override compose file that clears the device reservation before running.