### PR TITLE
fix: remove GPU reservation from training compose, add gpu override file

### DIFF
--- a/.github/workflows/manual-generate-synthetic-interactions.yml
+++ b/.github/workflows/manual-generate-synthetic-interactions.yml
@@ -113,21 +113,11 @@ jobs:
           REPO_PATH="/home/$HETZNER_USER/git-query"
           cd "\$REPO_PATH"
 
-          cat > "\$REPO_PATH/.runtime/docker-compose.training-cpu.yml" << 'EOF'
-          services:
-            training:
-              deploy:
-                resources:
-                  reservations:
-                    devices: []
-          EOF
-
           echo "Triggering LGBM-only retraining via docker-compose..."
           docker compose \
             -f infrastructure/docker/docker-compose.base.yml \
             -f infrastructure/docker/docker-compose.mlflow.yml \
             -f infrastructure/docker/docker-compose.training.yml \
-            -f .runtime/docker-compose.training-cpu.yml \
             --env-file .env \
             run --rm -e ENABLE_EMBEDDING_TRAINING=false training
 

--- a/.github/workflows/manual-retrain-lgbm.yml
+++ b/.github/workflows/manual-retrain-lgbm.yml
@@ -58,21 +58,11 @@ jobs:
           echo "Building training image..."
           docker build -f infrastructure/docker/Dockerfile.training -t git-query-training .
 
-          cat > "\$REPO_PATH/.runtime/docker-compose.training-cpu.yml" << 'EOF'
-          services:
-            training:
-              deploy:
-                resources:
-                  reservations:
-                    devices: []
-          EOF
-
           echo "Triggering LGBM-only retraining via docker-compose..."
           docker compose \
             -f infrastructure/docker/docker-compose.base.yml \
             -f infrastructure/docker/docker-compose.mlflow.yml \
             -f infrastructure/docker/docker-compose.training.yml \
-            -f .runtime/docker-compose.training-cpu.yml \
             --env-file .env \
             run --rm -e ENABLE_EMBEDDING_TRAINING=false training
 

--- a/infrastructure/docker/docker-compose.training-gpu.yml
+++ b/infrastructure/docker/docker-compose.training-gpu.yml
@@ -1,0 +1,12 @@
+# GPU override for training — include only on hosts with NVIDIA Container Toolkit
+# Usage: docker compose -f docker-compose.base.yml -f docker-compose.training.yml -f docker-compose.training-gpu.yml up
+
+services:
+  training:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]

--- a/infrastructure/docker/docker-compose.training.yml
+++ b/infrastructure/docker/docker-compose.training.yml
@@ -40,15 +40,6 @@ services:
       - LGBM_CANDIDATES_PER_QUERY=${LGBM_CANDIDATES_PER_QUERY:-100}
       - LGBM_NUM_BOOST_ROUNDS=${LGBM_NUM_BOOST_ROUNDS:-300}
 
-    # Training can run on CPU-only hosts used by CI/deploy runners.
-    # GPU support: requires NVIDIA Container Toolkit on the host.
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
     depends_on:
       mlflow:
         condition: service_healthy


### PR DESCRIPTION
Docker Compose list merging can't clear a list with an empty override. The real fix is to remove the GPU reservation from the base training compose so it works on CPU-only hosts by default, and add `docker-compose.training-gpu.yml` as an opt-in override for GPU-enabled hosts.