### PR TITLE
fix: pass api keys explicitly to LGBM training container

### DIFF
--- a/.github/workflows/manual-retrain-lgbm.yml
+++ b/.github/workflows/manual-retrain-lgbm.yml
@@ -33,6 +33,8 @@ jobs:
           HETZNER_USER: ${{ secrets.INFRA_HETZNER_USER }}
           HETZNER_HOST: ${{ secrets.INFRA_HETZNER_HOST }}
           DEFAULT_BRANCH: ${{ github.ref_name }}
+          APIKEY_MONGODB: ${{ secrets.APIKEY_MONGODB }}
+          APIKEY_QDRANT: ${{ secrets.APIKEY_QDRANT }}
         run: |
           ssh "$HETZNER_USER@$HETZNER_HOST" bash -s << ENDSSH
           set -euo pipefail
@@ -64,7 +66,11 @@ jobs:
             -f infrastructure/docker/docker-compose.mlflow.yml \
             -f infrastructure/docker/docker-compose.training.yml \
             --env-file .env \
-            run --rm -e ENABLE_EMBEDDING_TRAINING=false training
+            run --rm \
+            -e ENABLE_EMBEDDING_TRAINING=false \
+            -e APIKEY_MONGODB="$APIKEY_MONGODB" \
+            -e APIKEY_QDRANT="$APIKEY_QDRANT" \
+            training
 
           echo "Retraining complete."
           ENDSSH


### PR DESCRIPTION
Server `.env` doesn't include `APIKEY_MONGODB` / `APIKEY_QDRANT` — they live only in GitHub secrets. Without them the gateway returns 401, the pipeline fetches 0 repos, and training is skipped.

Passes both keys via `-e` flags on `docker compose run`.